### PR TITLE
Improve test coverage for all code paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Improve test coverage
+
 ## 2.0.0
 
 - Update UUID generation to robust v4 implementation

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -2,11 +2,64 @@ const uuid = require("../");
 const isUuid = require("is-uuid");
 
 describe("uuid", () => {
+  let originalCrypto;
+
+  beforeEach(() => {
+    originalCrypto = global.crypto;
+  });
+
+  afterEach(() => {
+    global.crypto = originalCrypto;
+  });
+
   it("returns valid v4 UUIDs", () => {
     let i;
 
     for (i = 0; i < 10; i++) {
       expect(isUuid.v4(uuid())).toBe(true);
     }
+  });
+
+  it("returns unique UUIDs on each call", () => {
+    const results = new Set();
+
+    for (let i = 0; i < 20; i++) {
+      results.add(uuid());
+    }
+
+    expect(results.size).toBe(20);
+  });
+
+  it("falls back to crypto.getRandomValues when crypto.randomUUID is not available", () => {
+    global.crypto = {
+      getRandomValues: (buf) => {
+        for (let i = 0; i < buf.length; i++) buf[i] = 0x00;
+        return buf;
+      },
+    };
+
+    expect(uuid()).toBe("00000000-0000-4000-8000-000000000000");
+  });
+
+  it("falls back to crypto.getRandomValues when crypto.randomUUID throws", () => {
+    global.crypto = {
+      randomUUID: () => {
+        throw new Error("Not allowed");
+      },
+      getRandomValues: (buf) => {
+        for (let i = 0; i < buf.length; i++) buf[i] = 0xff;
+        return buf;
+      },
+    };
+
+    expect(uuid()).toBe("ffffffff-ffff-4fff-bfff-ffffffffffff");
+  });
+
+  it("throws when no secure random source is available", () => {
+    delete global.crypto;
+
+    expect(() => uuid()).toThrow(
+      "@braintree/uuid: No secure random source available",
+    );
   });
 });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -13,9 +13,7 @@ describe("uuid", () => {
   });
 
   it("returns valid v4 UUIDs", () => {
-    let i;
-
-    for (i = 0; i < 10; i++) {
+    for (let i = 0; i < 10; i++) {
       expect(isUuid.v4(uuid())).toBe(true);
     }
   });


### PR DESCRIPTION
# Summary of changes

- Add uniqueness assertion across multiple calls
- Test `crypto.getRandomValues` fallback path
- Test fallthrough when `crypto.randomUUID` throws
- Test version and variant bit masking in `getRandomValues` fallback
- Test error thrown when no secure random source is available

## Checklist

- [x] Added a changelog entry
- [x] Relevant test coverage
- [x] Tested and confirmed flows affected by this change are functioning as expected

## Authors

@lvandenboom

### Reviewers

@braintree/team-sdk-js