### PR TITLE
fix: restrict GITHUB_TOKEN permissions in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Unit Tests on Ubuntu"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ on:
           - minor
           - patch
 
+permissions:
+  contents: read
+
 env:
   NPM_REGISTRY: https://registry.npmjs.org/
 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: write
+
 jobs:
   create_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary of changes

- Add explicit `permissions: contents: read` block to `.github/workflows/ci.yml` and `.github/workflows/publish.yml`
- Add explicit `permissions: contents: write` block to `.github/workflows/release-notes.yml` (required for creating GitHub releases)
- Limits `GITHUB_TOKEN` to the minimum scope required for each workflow

## Checklist

- [ ] Added a changelog entry
- [ ] Relevant test coverage
- [x] Tested and confirmed flows affected by this change are functioning as expected

## Authors

@lvandenboom

## Reviewers

@braintree/team-sdk-js