### PR TITLE
Add coverage threshold and migrate CI to shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@3d3621c5bb46edf879370cec4e63a34d345db4cf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,4 +11,4 @@ on:
 
 jobs:
   ci:
-    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@main
+    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@3d3621c5bb46edf879370cec4e63a34d345db4cf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,4 @@ permissions:
 
 jobs:
   ci:
-    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@3d3621c5bb46edf879370cec4e63a34d345db4cf
+    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@17a3922575160e8e3ffdb7ecc76c6a3dbfd6a50a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "Unit Tests"
+name: "CI"
 
 on:
   push:
@@ -10,16 +10,5 @@ on:
       - "*"
 
 jobs:
-  build:
-    name: "Unit Tests on Ubuntu"
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-      - run: npm ci
-      - run: npx eslint . --ext .js,.ts
-      - run: npm test
+  ci:
+    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@main

--- a/package.json
+++ b/package.json
@@ -20,6 +20,18 @@
     "url": "https://github.com/braintree/uuid/issues"
   },
   "homepage": "https://github.com/braintree/uuid#readme",
+  "jest": {
+    "collectCoverage": true,
+    "collectCoverageFrom": ["index.js"],
+    "coverageThreshold": {
+      "global": {
+        "lines": 80,
+        "statements": 80,
+        "branches": 80,
+        "functions": 80
+      }
+    }
+  },
   "devDependencies": {
     "eslint": "^8.57.0",
     "eslint-config-braintree": "^6.0.0",


### PR DESCRIPTION
## Summary
- Adds 80% `coverageThreshold` (lines/statements/branches/functions) to enforce coverage requirements
- Migrates CI workflow to shared reusable workflow from [web-sdk-github-actions](https://github.com/braintree/web-sdk-github-actions)

## Test plan
- [x] `npm test` passes locally with new coverage threshold
- [ ] CI passes using shared workflow