### PR TITLE
Document shared automation account usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ Used in:
 - [braintree-web](https://github.com/braintree/braintree-web)
 - [braintree-web-drop-in](https://github.com/braintree/braintree-web-drop-in)
 - [framebus](https://github.com/braintree/framebus)
+
+## Automation
+
+This repository uses GitHub Actions for CI, version bumping, publishing, and release notes. Automated commits (e.g., version bumps) are attributed to `github-actions[bot]`.
+
+Historically, a shared automation account (`bt-code@paypal.com`, displayed as "Braintree Open Source") was used for CI/CD operations such as merging pull requests and version bumps. That account is no longer actively used for this repository. Its prior use was limited to automated release and merge operations and is documented here as an accepted exception to the project's policy against shared accounts in development workflows.


### PR DESCRIPTION
## Summary
- Adds an "Automation" section to the README documenting current and historical CI/CD automation accounts
- Current automated commits use `github-actions[bot]`
- Historical use of `bt-code@paypal.com` ("Braintree Open Source") for CI/CD merge and release operations is documented as an accepted exception to the shared-account policy